### PR TITLE
fix: add explicit permissions to release-please job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
The release-please job was failing because GitHub Actions was not
permitted to create pull requests. Add explicit job-level permissions
for contents:write and pull-requests:write.

Note: The repository setting "Allow GitHub Actions to create and approve
pull requests" must also be enabled under Settings > Actions > General.

https://claude.ai/code/session_01NWMNEfWFBCvUq9ehUbpvdR